### PR TITLE
Setup commitizen and semantic-release

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@ Gigwalk
 =======
 
 [![CircleCI](https://circleci.com/gh/gigwalk-corp/gigwalk-node.svg?style=svg)](https://circleci.com/gh/gigwalk-corp/gigwalk-node)
+[![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
+[![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 
 > "API Client in JS for node and the browser."
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,15 @@
 machine:
-    node:
-        version: 6.3.1
+  node:
+    version: 6.3.1
+
 test:
-    post:
-        - npm run flow
-        - npm run eslint
+  post:
+    - npm run flow
+    - npm run eslint
+
+deployment:
+  npm:
+    branch: master
+    owner: gigwalk-corp
+    commands:
+        - npm run semantic-release

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gigwalk",
-  "version": "1.0.0",
+  "version": "0.0.0-semantic-release",
   "description": "Gigwalk API Client - universal.",
   "main": "index.js",
   "scripts": {
@@ -8,15 +8,15 @@
     "eslint": "eslint .",
     "flow": "flow",
     "test": "NODE_ENV=test mocha",
-    "test-debug": "bugger --brk ./node_modules/.bin/_mocha"
+    "test-debug": "bugger --brk ./node_modules/.bin/_mocha",
+    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/gigwalk-corp/gigwalk.git"
+    "url": "https://github.com/gigwalk-corp/gigwalk-node.git"
   },
   "keywords": [
     "gigwalk",
-    "api",
     "api",
     "client",
     "axios"
@@ -24,9 +24,9 @@
   "author": "Steven Bassett <steven.j.bassett@gmail.com>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/gigwalk-corp/gigwalk/issues"
+    "url": "https://github.com/gigwalk-corp/gigwalk-node/issues"
   },
-  "homepage": "https://github.com/gigwalk-corp/gigwalk#readme",
+  "homepage": "https://github.com/gigwalk-corp/gigwalk-node#readme",
   "dependencies": {
     "axios": "^0.13.1",
     "babel-polyfill": "^6.9.1",
@@ -45,6 +45,8 @@
     "chai": "^3.5.0",
     "chai-as-promised": "^5.3.0",
     "chai-json-schema": "^1.2.0",
+    "condition-circle": "^1.2.0",
+    "cz-conventional-changelog": "^1.1.6",
     "dotenv": "^2.0.0",
     "eslint": "^3.1.1",
     "eslint-config-airbnb": "^9.0.1",
@@ -59,7 +61,16 @@
     "flow-typed": "^2.0.0-beta.6",
     "mocha": "^2.5.3",
     "mockery": "^1.7.0",
+    "semantic-release": "^4.3.5",
     "sinon": "^1.17.5",
     "sinon-chai": "^2.8.0"
+  },
+  "config": {
+    "commitizen": {
+      "path": "./node_modules/cz-conventional-changelog"
+    }
+  },
+  "release": {
+    "verifyConditions": "condition-circle"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "babel src -d lib",
     "eslint": "eslint .",
     "flow": "flow",
-    "test": "NODE_ENV=test mocha",
+    "test": "NODE_ENV=test mocha --timeout 20000",
     "test-debug": "bugger --brk ./node_modules/.bin/_mocha",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },


### PR DESCRIPTION
Configured CircleCI to use `semantic-release` to automatically publish new releases to npm when the build passes. I added this during the deployment phase, so it will only trigger when a PR targeting master is merged.

I also installed `commitizen` globally on my machine to make formatting commit messages super easy. I **highly recommend** you do the same. It's super important to write meaningful commit messages in order for `semantic-release` to prove useful. It actually uses commit messages to determine the next release.

You can read more about this packages below:
https://www.npmjs.com/package/semantic-release
https://www.npmjs.com/package/commitizen