### PR TITLE
fix(api-tests): omit transform-runtime plugin when running mocha tests

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,13 +5,17 @@
   ],
   "plugins": [
       "transform-flow-comments",
-      "syntax-flow",
-      "transform-runtime"
+      "syntax-flow"
   ],
   "env": {
     "test": {
       "plugins": [
         "rewire"
+      ]
+    },
+    "production": {
+      "plugins": [
+        "transform-runtime"
       ]
     }
   }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.11.1",
     "babel-preset-stage-0": "^6.5.0",
-    "babel-register": "6.11.5",
+    "babel-register": "^6.11.5",
     "chai": "^3.5.0",
     "chai-as-promised": "^5.3.0",
     "chai-json-schema": "^1.2.0",


### PR DESCRIPTION
There seems to be a conflict between the transform-runtime and rewire
plugins for babel. When both are included, running `npm test` throws
a rather cryptic error. The stacktrace points to rewire being the
culprit, but tests run just fine when you remove transform-runtime.

Since we really only need the transform-runtime plugin to be enabled
for production builds, I updated .babelrc to include it when NODE_ENV
is set to production