### PR TITLE
Revert "fix(api-tests): omit transform-runtime plugin when running mocha tests"

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,17 +5,13 @@
   ],
   "plugins": [
       "transform-flow-comments",
-      "syntax-flow"
+      "syntax-flow",
+      "transform-runtime"
   ],
   "env": {
     "test": {
       "plugins": [
         "rewire"
-      ]
-    },
-    "production": {
-      "plugins": [
-        "transform-runtime"
       ]
     }
   }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.11.1",
     "babel-preset-stage-0": "^6.5.0",
-    "babel-register": "^6.11.5",
+    "babel-register": "6.11.5",
     "chai": "^3.5.0",
     "chai-as-promised": "^5.3.0",
     "chai-json-schema": "^1.2.0",


### PR DESCRIPTION
Reverts gigwalk-corp/gigwalk-node#67