### PR TITLE
chore(package.json): update

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "gigwalk",
   "version": "0.0.0-semantic-release",
   "description": "Gigwalk API Client - universal.",
-  "main": "lib/index.js",
+  "main": "./lib",
   "scripts": {
     "prebuild": "rm -rf lib",
     "build": "NODE_ENV=production babel src -d lib -s",


### PR DESCRIPTION
- updating  to follow similar imports like react-toolbox to allow things like:
```js
import type { APIPromise } from 'gigwalk/api/resource';
```