### PR TITLE
Fix: stringForQueryObject prefix question mark.

### DIFF
--- a/src/api/resource.js
+++ b/src/api/resource.js
@@ -54,6 +54,6 @@ export default class Resource {
                     return `${str}${i === 0 ? '?' : '&'}${key}=${value}`;
                 }
                 return str;
-            }, '');
+            }, '?');
     }
 }


### PR DESCRIPTION
Found that using the query object does not insert question mark to separate params from path.